### PR TITLE
Add collapsible insight groups

### DIFF
--- a/vscode-extension/src/checks/postgres/connection_check.js
+++ b/vscode-extension/src/checks/postgres/connection_check.js
@@ -5,7 +5,6 @@ const BaseCheck = require('../../checks/base_check');
  * This check is marked as blocking so other checks are skipped when it fails.
  */
 class ConnectionCheck extends BaseCheck {
-  static id = 'connection';
   constructor(databaseManager) {
     super(databaseManager, { blocking: true });
   }

--- a/vscode-extension/webview/src/components/insights/InsightGroup.svelte
+++ b/vscode-extension/webview/src/components/insights/InsightGroup.svelte
@@ -1,0 +1,52 @@
+<script>
+  import InsightCard from './InsightCard.svelte';
+  export let title;
+  export let insights = [];
+  let expanded = insights.length > 0;
+  const toggle = () => expanded = !expanded;
+</script>
+
+<div class="insight-group">
+  <div class="group-header" on:click={toggle}>
+    <h3>{title}</h3>
+    {#if insights.length === 0}
+      <span class="status-ok">✓</span>
+    {:else}
+      <span class="issue-count">{insights.length} issues</span>
+      <span class="toggle">{expanded ? '▼' : '▶'}</span>
+    {/if}
+  </div>
+  {#if expanded && insights.length > 0}
+    <div class="group-insights">
+      {#each insights as insight}
+        <InsightCard {insight} />
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .group-header {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    border-bottom: 1px solid var(--dark-border);
+    padding: 8px 0;
+  }
+  .group-header h3 {
+    margin: 0;
+    flex: 1;
+  }
+  .status-ok {
+    color: var(--success-green);
+  }
+  .issue-count {
+    margin-right: 8px;
+  }
+  .toggle {
+    margin-left: auto;
+  }
+  .group-insights {
+    padding: 12px 0;
+  }
+</style>

--- a/vscode-extension/webview/src/components/insights/cards/ConfigOptimizationCard.svelte
+++ b/vscode-extension/webview/src/components/insights/cards/ConfigOptimizationCard.svelte
@@ -1,6 +1,8 @@
 <script>
   import { getSeverityClass, getSeverityText } from '../../../lib/utils/severity';
   export let insight;
+  let expanded = false;
+  const toggle = () => expanded = !expanded;
 
   function formatValue(value) {
     if (typeof value === 'number') {
@@ -11,13 +13,15 @@
 </script>
 
 <div class="insight-config-optimization">
-  <div class="insight-header">
+  <div class="insight-header" on:click={toggle}>
     <span class="icon">⚙️</span>
     <span>{insight.title}</span>
     <span class="severity-badge {getSeverityClass(insight.severity_level)}">
       {getSeverityText(insight.severity_level)}
     </span>
+    <span class="toggle">{expanded ? '▼' : '▶'}</span>
   </div>
+  {#if expanded}
   <div class="insight-details">
     <div class="detail-group">
       <div class="detail-label">Parameter</div>
@@ -42,6 +46,7 @@
       </div>
     </div>
   </div>
+  {/if}
 </div>
 
 <style>
@@ -58,6 +63,7 @@
     align-items: center;
     margin-bottom: 12px;
     gap: 8px;
+    cursor: pointer;
   }
 
   .icon {
@@ -94,6 +100,10 @@
   .severity-badge.critical {
     background-color: var(--error-red);
     color: var(--text-light);
+  }
+
+  .toggle {
+    margin-left: auto;
   }
 
   .insight-details {

--- a/vscode-extension/webview/src/components/insights/cards/RedundantIndexCard.svelte
+++ b/vscode-extension/webview/src/components/insights/cards/RedundantIndexCard.svelte
@@ -1,16 +1,20 @@
 <script>
   import { getSeverityClass, getSeverityText } from '../../../lib/utils/severity';
   export let insight;
+  let expanded = false;
+  const toggle = () => expanded = !expanded;
 </script>
 
 <div class="insight-redundant-index">
-  <div class="insight-header">
+  <div class="insight-header" on:click={toggle}>
     <span class="icon">🔄</span>
     <span>{insight.title}</span>
     <span class="severity-badge {getSeverityClass(insight.severity_level)}">
       {getSeverityText(insight.severity_level)}
     </span>
+    <span class="toggle">{expanded ? '▼' : '▶'}</span>
   </div>
+  {#if expanded}
   <div class="insight-details">
     <div class="detail-group">
       <div class="detail-label">Table</div>
@@ -35,6 +39,7 @@
       </div>
     </div>
   </div>
+  {/if}
 </div>
 
 <style>
@@ -51,6 +56,7 @@
     align-items: center;
     margin-bottom: 12px;
     gap: 8px;
+    cursor: pointer;
   }
 
   .icon {
@@ -87,6 +93,10 @@
   .severity-badge.critical {
     background-color: var(--error-red);
     color: var(--text-light);
+  }
+
+  .toggle {
+    margin-left: auto;
   }
 
   .insight-details {

--- a/vscode-extension/webview/src/components/insights/cards/SlowQueryCard.svelte
+++ b/vscode-extension/webview/src/components/insights/cards/SlowQueryCard.svelte
@@ -1,6 +1,8 @@
 <script>
   import { getSeverityClass, getSeverityText } from '../../../lib/utils/severity';
   export let insight;
+  let expanded = false;
+  const toggle = () => expanded = !expanded;
 
   function formatTime(ms) {
     if (ms < 1000) {
@@ -15,13 +17,15 @@
 </script>
 
 <div class="insight-slow-query">
-  <div class="insight-header">
+  <div class="insight-header" on:click={toggle}>
     <span class="icon">⏱️</span>
     <span>{insight.title}</span>
     <span class="severity-badge {getSeverityClass(insight.severity_level)}">
       {getSeverityText(insight.severity_level)}
     </span>
+    <span class="toggle">{expanded ? '▼' : '▶'}</span>
   </div>
+  {#if expanded}
   <div class="insight-details">
     <div class="detail-group">
       <div class="detail-label">Query</div>
@@ -60,6 +64,7 @@
       </div>
     {/if}
   </div>
+  {/if}
 </div>
 
 <style>
@@ -76,6 +81,7 @@
     align-items: center;
     margin-bottom: 12px;
     gap: 8px;
+    cursor: pointer;
   }
 
   .icon {
@@ -112,6 +118,10 @@
   .severity-badge.critical {
     background-color: var(--error-red);
     color: var(--text-light);
+  }
+
+  .toggle {
+    margin-left: auto;
   }
 
   .insight-details {

--- a/vscode-extension/webview/src/components/insights/cards/UnusedIndexCard.svelte
+++ b/vscode-extension/webview/src/components/insights/cards/UnusedIndexCard.svelte
@@ -1,6 +1,8 @@
 <script>
   import { getSeverityClass, getSeverityText } from '../../../lib/utils/severity';
   export let insight;
+  let expanded = false;
+  const toggle = () => expanded = !expanded;
 
   function formatBytes(bytes) {
     if (!bytes || isNaN(bytes) || bytes < 0) return 'Unknown size';
@@ -13,13 +15,15 @@
 </script>
 
 <div class="insight-unused-index">
-  <div class="insight-header">
+  <div class="insight-header" on:click={toggle}>
     <span class="icon">📊</span>
     <span>{insight.title}</span>
     <span class="severity-badge {getSeverityClass(insight.severity_level)}">
       {getSeverityText(insight.severity_level)}
     </span>
+    <span class="toggle">{expanded ? '▼' : '▶'}</span>
   </div>
+  {#if expanded}
   <div class="insight-details">
     <div class="detail-group">
       <div class="detail-label">Table</div>
@@ -50,6 +54,7 @@
       </div>
     </div>
   </div>
+  {/if}
 </div>
 
 <style>
@@ -66,6 +71,7 @@
     align-items: center;
     margin-bottom: 12px;
     gap: 8px;
+    cursor: pointer;
   }
 
   .icon {
@@ -102,6 +108,10 @@
   .severity-badge.critical {
     background-color: var(--error-red);
     color: var(--text-light);
+  }
+
+  .toggle {
+    margin-left: auto;
   }
 
   .insight-details {

--- a/vscode-extension/webview/src/components/insights/cards/WarningCard.svelte
+++ b/vscode-extension/webview/src/components/insights/cards/WarningCard.svelte
@@ -1,6 +1,8 @@
 <script>
   import { getSeverityClass, getSeverityText, getSeverityLevel } from '../../../lib/utils/severity';
   export let insight;
+  let expanded = false;
+  const toggle = () => expanded = !expanded;
 
   // Helper function to format values based on their type
   function formatValue(value) {
@@ -23,13 +25,15 @@
 </script>
 
 <div class="insight-warning">
-  <div class="insight-header">
+  <div class="insight-header" on:click={toggle}>
     <span class="icon">{insight.kind === 'warning' ? '⚠️' : 'ℹ️'}</span>
     <span>{insight.title}</span>
     <span class="severity-badge {getSeverityClass(insight.severity_level || getSeverityLevel(insight.context.impact))}">
       {getSeverityText(insight.severity_level || getSeverityLevel(insight.context.impact))}
     </span>
+    <span class="toggle">{expanded ? '▼' : '▶'}</span>
   </div>
+  {#if expanded}
   <div class="insight-details">
     {#if insight.context.description || insight.context.reason}
       <div class="detail-group">
@@ -62,6 +66,7 @@
       </div>
     {/if}
   </div>
+  {/if}
 </div>
 
 <style>
@@ -78,6 +83,7 @@
     align-items: center;
     margin-bottom: 12px;
     gap: 8px;
+    cursor: pointer;
   }
 
   .icon {
@@ -114,6 +120,10 @@
   .severity-badge.critical {
     background-color: var(--error-red);
     color: var(--text-light);
+  }
+
+  .toggle {
+    margin-left: auto;
   }
 
   .insight-details {

--- a/vscode-extension/webview/src/sections/Insights.svelte
+++ b/vscode-extension/webview/src/sections/Insights.svelte
@@ -1,13 +1,33 @@
 <script>
   import { onMount } from 'svelte';
   import { vscode } from '~/lib/vscode';
-  import InsightCard from '../components/insights/InsightCard.svelte';
+  import InsightGroup from '../components/insights/InsightGroup.svelte';
   import LoadingState from '../components/insights/LoadingState.svelte';
   import RefreshButton from '../components/common/RefreshButton.svelte';
   
   export let connection;
 
   let insights = [];
+  const GROUPS = [
+    { kind: 'unused-index', title: 'Unused Indexes' },
+    { kind: 'redundant-index', title: 'Redundant Indexes' },
+    { kind: 'config-optimization', title: 'Configuration Optimizations' },
+    { kind: 'slow-query', title: 'Slow Queries' },
+    { kind: 'permission-failure', title: 'Permission Issues' },
+    { kind: 'missing-extension', title: 'Missing Extensions' },
+    { kind: 'check-validation-failed', title: 'Validation Failures' },
+    { kind: 'check-failed', title: 'Check Errors' },
+    { kind: 'connection-failed', title: 'Connection Issues' },
+    { kind: 'prerequisites-failure', title: 'Prerequisite Checks' },
+    { kind: 'config-analysis-failure', title: 'Config Analysis Failures' }
+  ];
+  let groupedInsights = [];
+
+  $: groupedInsights = GROUPS.map(g => ({
+    title: g.title,
+    kind: g.kind,
+    insights: insights.filter(i => i.kind === g.kind)
+  }));
   let isLoading = true;
   let error = null;
   let lastRefreshTime = null;
@@ -74,9 +94,9 @@
       </div>
     {:else}
       <ul>
-        {#each insights as insight}
+        {#each groupedInsights as group}
           <li class="insight-item">
-            <InsightCard {insight} />
+            <InsightGroup title={group.title} insights={group.insights} />
           </li>
         {/each}
       </ul>


### PR DESCRIPTION
## Summary
- make insight cards collapsible
- group insights by type and show a green check mark when a group has no issues
- remove explicit id fields on check classes

## Testing
- `npm test` *(fails: vite command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68571e2cd4a88324b3856936c2e3df62