### PR TITLE
Add security note to no-connection screen

### DIFF
--- a/vscode-extension/webview/src/App.svelte
+++ b/vscode-extension/webview/src/App.svelte
@@ -101,6 +101,9 @@ import ConnectionUrlForm from './components/connections/ConnectionUrlForm.svelte
             >
           </li>
         </ol>
+        <p class="highlight-note security-note">
+          AutoDBA runs entirely on your machine. Database credentials are stored locally using VS Code's Secret Storage, and the extension sends no credentials or usage data anywhere.
+        </p>
       </div>
     {/if}
   </div>

--- a/vscode-extension/webview/src/styles/global.css
+++ b/vscode-extension/webview/src/styles/global.css
@@ -158,6 +158,15 @@ label {
   color: var(--text-light);
 }
 
+/* Highlighted note style */
+.highlight-note {
+  padding: 12px;
+  border-left: 4px solid var(--primary-blue);
+  background-color: var(--vscode-editor-selectionBackground, rgba(255, 255, 255, 0.1));
+  border-radius: 4px;
+  margin-top: 12px;
+}
+
 /* Common loading state styles */
 .loading {
   text-align: center;


### PR DESCRIPTION
## Summary
- reassure users about credential storage and local operations
- highlight new message in the webview

## Testing
- `npm run lint`
- `npm test` *(fails: `mocha: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6858c27ca63c8331acddc26d8f8a2d9a